### PR TITLE
feat: Redesigned UserContext and UserProvider

### DIFF
--- a/ferrous_frontend/src/components/admin-guard.tsx
+++ b/ferrous_frontend/src/components/admin-guard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { USER_CONTEXT } from "../context/user";
+import USER_CONTEXT from "../context/user";
 import { ROUTES } from "../routes";
 import { toast } from "react-toastify";
 

--- a/ferrous_frontend/src/context/user.tsx
+++ b/ferrous_frontend/src/context/user.tsx
@@ -2,38 +2,49 @@ import React from "react";
 import { GetUser } from "../api/generated/models";
 import { Api } from "../api/api";
 import Loading from "../components/loading";
-import { StatusCode } from "../api/error";
+import { ApiError, StatusCode } from "../api/error";
 import { toast } from "react-toastify";
 import Login from "../views/login";
 
+/** The global {@link UserProvider} instance */
+let USER_PROVIDER: UserProvider | null = null;
+
+/** Data provided by the {@link USER_CONTEXT} */
 export type UserContext = {
     user: GetUser;
-    resetUser(): void;
 };
-export const USER_CONTEXT = React.createContext<UserContext>({
+
+/** {@link React.Context Context} to access {@link GetUser user information} */
+const USER_CONTEXT = React.createContext<UserContext>({
     user: { username: "", displayName: "", uuid: "", createdAt: new Date(0), admin: false, lastLogin: null },
-    resetUser() {},
 });
 USER_CONTEXT.displayName = "UserContext";
+export default USER_CONTEXT;
 
 type UserProviderProps = {
     children?: React.ReactNode;
 };
+type UserProviderState = {
+    user: GetUser | "unauthenticated" | null;
+};
 
-/** Component for managing and providing the {@link UserContext} */
-export function UserProvider(props: UserProviderProps) {
-    type UserState = GetUser | "unauthenticated" | null;
-    const [user, setUser] = React.useState<UserState>(null);
+/**
+ * Component for managing and providing the {@link UserContext}
+ *
+ * This is a **singleton** only use at most **one** instance in your application.
+ */
+export class UserProvider extends React.Component<UserProviderProps, UserProviderState> {
+    state: UserProviderState = { user: null };
 
-    React.useEffect(() => {
-        if (user == null)
+    fetchUser() {
+        if (this.state.user == null)
             Api.user.get().then((result) =>
                 result.match(
-                    (user) => setUser(user),
+                    (user) => this.setState({ user }),
                     (error) => {
                         switch (error.status_code) {
                             case StatusCode.Unauthenticated:
-                                setUser("unauthenticated");
+                                this.setState({ user: "unauthenticated" });
                                 break;
                             default:
                                 toast.error(error.message);
@@ -42,30 +53,68 @@ export function UserProvider(props: UserProviderProps) {
                     }
                 )
             );
-    }, [user]);
+        }
 
-    const resetUser = React.useCallback(
-        function () {
-            setUser(null);
-        },
-        [setUser]
-    );
-        
-    switch (user) {
-        case null:
-            return <Loading />;
-        case "unauthenticated":
-            return <Login onLogin={resetUser} />;
+        componentDidMount() {
+            if (USER_PROVIDER === null) USER_PROVIDER = this;
+            else if (USER_PROVIDER === this) console.error("UserProvider did mount twice");
+            else console.error("Two instances of UserProvider are used");
+    
+            this.fetchUser();
+        }
+    
+        componentDidUpdate(prevProps: Readonly<UserProviderProps>, prevState: Readonly<UserProviderState>) {
+            this.fetchUser();
+        }
+    
+        componentWillUnmount() {
+            if (USER_PROVIDER === this) USER_PROVIDER = null;
+            else if (USER_PROVIDER === null) console.error("UserProvider instance did unmount twice");
+            else console.error("Two instances of UserProvider are used");
+        }
+    
+        render() {
+            switch (this.state.user) {
+                case null:
+                    return <Loading />;
+                case "unauthenticated":
+                    return <Login onLogin={() => this.setState({ user: null })} />;
+                default:
+                    return (
+                        <USER_CONTEXT.Provider
+                            value={{
+                                user: this.state.user,
+                            }}
+                        >
+                            {this.props.children}
+                        </USER_CONTEXT.Provider>
+                    );
+            }
+        }
+    }
+       
+/**
+ * Reset the user information provided by {@link USER_CONTEXT}.
+ *
+ * This triggers an api call and might result in the user having to log in again.
+ */
+export function resetUser() {
+    if (USER_PROVIDER !== null) USER_PROVIDER.setState({ user: null });
+    else console.warn("resetUser has been called without a UserProvider");
+}    
+
+/**
+ * Inspect an error and handle the {@link StatusCode.Unauthenticated Unauthenticated} status code by requiring the user to log in again.
+ *
+ * @param error {@link ApiError} to inspect for {@link StatusCode.Unauthenticated Unauthenticated}
+ */
+export function inspectError(error: ApiError) {
+    switch (error.status_code) {
+        case StatusCode.Unauthenticated:
+            if (USER_PROVIDER !== null) USER_PROVIDER.setState({ user: "unauthenticated" });
+            else console.warn("inspectError has been called without a UserProvider");
+            break;
         default:
-            return (
-                <USER_CONTEXT.Provider
-                    value={{
-                        user,
-                        resetUser,
-                    }}
-                >
-                    {props.children}
-                </USER_CONTEXT.Provider>
-            );
+            break;
     }
 }

--- a/ferrous_frontend/src/views/me.tsx
+++ b/ferrous_frontend/src/views/me.tsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 import "../styling/me.css";
 import Input from "../components/input";
 import { check } from "../utils/helper";
-import { USER_CONTEXT } from "../context/user";
+import USER_CONTEXT, { resetUser } from "../context/user";
 
 type MeProps = {};
 type MeState = {
@@ -74,7 +74,7 @@ export default class Me extends React.Component<MeProps, MeState> {
             result.match(
                 () => {
                     toast.success("Changed password successfully");
-                    this.context.resetUser();
+                    resetUser();
                 },
                 (err) => toast.error(err.message)
             )

--- a/ferrous_frontend/src/views/menu.tsx
+++ b/ferrous_frontend/src/views/menu.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ROUTES } from "../routes";
-import { USER_CONTEXT } from "../context/user";
+import USER_CONTEXT from "../context/user";
 
 type MenuProps = {};
 type MenuState = {};


### PR DESCRIPTION
This commit essentially adds an `inspectError` function to be used in every api request.
Passing this function into the tree using a context would yield unneccessary overhead.
So instead the UserProvider was redesigned to be a singlton with global state.